### PR TITLE
Attempt to use sps client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "dependencies": {
         "next": "^13.4.19",
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "sps-client": "github:securepollingsystem/node-client"
       }
     },
     "node_modules/@next/env": {
@@ -349,6 +350,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sps-client": {
+      "version": "1.0.3",
+      "resolved": "git+ssh://git@github.com/securepollingsystem/node-client.git#46d97343b7a264a042a0906e262aa20bffe5107d",
+      "license": "GPL"
+    },
     "node_modules/streamsearch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
@@ -587,6 +593,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
+    },
+    "sps-client": {
+      "version": "git+ssh://git@github.com/securepollingsystem/node-client.git#46d97343b7a264a042a0906e262aa20bffe5107d",
+      "from": "sps-client@github:securepollingsystem/node-client"
     },
     "streamsearch": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "next": "^13.4.19",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "sps-client": "github:securepollingsystem/node-client"
   }
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,8 @@
 import { getItems, getSubset } from '../src/db';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
+import * as SPSClient from 'sps-client';
+console.log(SPSClient);
 
 export default function Home() {
   const [searchstring, setSearchstring] = useState("");


### PR DESCRIPTION
I installed the [node sps client](https://github.com/securepollingsystem/node-client/pulls) with `npm install https://github.com/securepollingsystem/node-client/pulls`. And tried to use it in the code. Then running this poject with `npm run dev` and going to `localhost:3000` I get this error:
![image](https://github.com/securepollingsystem/nextjs-blog/assets/598099/e64b983e-df6e-4f3c-bc4d-951e7cf79230)


My guess is this is from the [ecccrypto](https://github.com/bitchan/eccrypto) not being used in a way within the sps node client in a way that does not work in the browser. However the eccrypto website says it can be used with browserfy in the browser.